### PR TITLE
Add ability for bot owners & hosts to close this bot

### DIFF
--- a/cogs/secret_commands.py
+++ b/cogs/secret_commands.py
@@ -9,6 +9,20 @@ class Secret:
     async def on_ready(self):
         print("Secret Commands Cog was loaded successfully!")
 
+	
+	admins = [
+		108268232556703744, # Zeexel
+		200325748786069504, # Glitch
+		133693527296180224 # Ducky
+	]
+	
+	@commands.command()
+	async def stop(self, ctx):
+		if ctx.message.author.id in admins:
+			await ctx.send(":wave: Shutting down!")
+			await ctx.bot.logout()
+		else:
+			await ctx.send("No! Only the bot owners and hosts may stop the bot!")
     @commands.command()
     async def despacito(self, ctx, despaversion):
         if despaversion == '2':


### PR DESCRIPTION
### HOW IT WORKS
Loaded in the secret-commands cog, the command is not visible to users under the help menu. Upon running $stop, the bot will:
1. Check if your (static) Discord User ID matches Zeexel's (bot owner), Ducky's (bot host), or Glitch's (bot host)
2. If yes, log out.
3. (Specific to main bot) The systemd service detects that the bot has stopped, and reboots it.
### Why?
This PR allows us (main bot instance hosts/owners) to force the bot to apply patches by exiting and restarting, which triggers a git update.